### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Linkplay devices allow to save, using the control app on the phone/tablet, music
         entity_id: media_player.sound_room1
         preset: 1
 ```
-Preset count vary from device tyoe to type, usually the app shows how many presets can be stored maximum. The integration detects the max number and the command only accepts numbers from the allowed range.
+Preset count vary from device tyoe to type, usually the app shows how many presets can be stored maximum. The integration detects the max number and the command only accepts numbers from the allowed range. You can specify multiple entity ids separated by comma or use `all` to run the service against.
 
 ## Snapshot and restore
 
@@ -132,7 +132,7 @@ To restore the player state:
       data:
         entity_id: media_player.sound_room1
 ```
-Currently the following state is being snapshotted/restored:
+You can specify multiple entity ids separated by comma or use `all` to run the service against. Currently the following state is being snapshotted/restored:
 - Volume
 - Input source
 - Webradio stream (as long as it's configured as an input source)
@@ -268,7 +268,7 @@ Implemented commands:
 - `Reboot` - as name implies (a soft-reboot, only seems to restart the main loop in the Linkplay module, not MCU or other part).
 - `RouterMultiroomEnable` - theoretically router mode is enabled by default in firmwares above v4.2.8020, but there’s also a logic included to build it up, this command ensures to set the good priority. Only use if you have issues with multiroom in router mode.
 
-Results will appear in Lovelace UI's left pane as persistent notifications which can be dismissed.
+Results will appear in Lovelace UI's left pane as persistent notifications which can be dismissed. You can specify multiple entity ids separated by comma or use `all` to run the service against.
 
 
 ## About Linkplay

--- a/custom_components/linkplay/__init__.py
+++ b/custom_components/linkplay/__init__.py
@@ -30,7 +30,7 @@ ATTR_SOURCE = 'source'
 ATTR_TRACK = 'track'
 
 SERVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
+    vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids
 })
 
 JOIN_SERVICE_SCHEMA = SERVICE_SCHEMA.extend({
@@ -38,21 +38,21 @@ JOIN_SERVICE_SCHEMA = SERVICE_SCHEMA.extend({
 })
 
 PRESET_BUTTON_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
     vol.Required(ATTR_PRESET): cv.positive_int
 })
 
 CMND_SERVICE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
     vol.Required(ATTR_CMD): cv.string
 })
 
 REST_SERVICE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id
+    vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids
 })
 
 SNAP_SERVICE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
     vol.Optional(ATTR_SNAP, default=True): cv.boolean
 })
 
@@ -75,11 +75,13 @@ def setup(hass, config):
     def service_handle(service):
         """Handle services."""
         _LOGGER.debug("service_handle from id: %s",
-                      service.data.get('entity_id'))
-        entity_ids = service.data.get('entity_id')
+                      service.data.get(ATTR_ENTITY_ID))
+        entity_ids = service.data.get(ATTR_ENTITY_ID)
         entities = hass.data[DOMAIN].entities
 
         if entity_ids:
+            if entity_ids == 'all':
+                entity_ids = [e.entity_id for e in entities]
             entities = [e for e in entities if e.entity_id in entity_ids]
 
         if service.service == SERVICE_JOIN:
@@ -107,27 +109,27 @@ def setup(hass, config):
         elif service.service == SERVICE_PRESET:
             preset = service.data.get(ATTR_PRESET)
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**PRESET** entity: %s; preset: %s", device.entity_id, preset)
                     device.preset_button(preset)
 
         elif service.service == SERVICE_CMD:
             command = service.data.get(ATTR_CMD)
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**COMMAND** entity: %s; command: %s", device.entity_id, command)
                     device.execute_command(command)
 
         elif service.service == SERVICE_SNAP:
             switchinput = service.data.get(ATTR_SNAP)
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**SNAPSHOT** entity: %s;", device.entity_id)
                     device.snapshot(switchinput)
 
         elif service.service == SERVICE_REST:
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**RESTORE** entity: %s;", device.entity_id)
                     device.restore()
 
@@ -135,14 +137,14 @@ def setup(hass, config):
             in_slct = service.data.get(ATTR_SELECT)
             trk_src = service.data.get(ATTR_SOURCE)
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**GET TRACKS** entity: %s; source: %s; to: %s", device.entity_id, trk_src, in_slct)
                     device.fill_input_select(in_slct, trk_src)
 
         elif service.service == SERVICE_PLAY:
             track = service.data.get(ATTR_TRACK)
             for device in entities:
-                if device.entity_id == service.data.get(ATTR_ENTITY_ID):
+                if device.entity_id in entity_ids:
                     _LOGGER.debug("**PLAY TRACK** entity: %s; track: %s", device.entity_id, track)
                     device.play_track(track)
 

--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -1272,9 +1272,28 @@ class LinkPlayDevice(MediaPlayerEntity):
             return
 
         xml_tree = ET.fromstring(preset_map)
-        xml_tree.find('Key'+presetnum+'/Name').text = "Snapshot set by Home Assistant ("+result+")"
-        xml_tree.find('Key'+presetnum+'/Source').text = "SPOTIFY"
-        xml_tree.find('Key'+presetnum+'/PicUrl').text = "https://brands.home-assistant.io/_/media_player/icon.png"
+
+        try:
+            xml_tree.find('Key'+presetnum+'/Name').text = "Snapshot set by Home Assistant ("+result+")"
+        except:
+            data=xml_tree.find('Key'+presetnum)
+            snap=ET.SubElement(data,'Name')
+            snap.text = "Snapshot set by Home Assistant ("+result+")"
+
+        try:
+            xml_tree.find('Key'+presetnum+'/Source').text = "SPOTIFY"
+        except:
+            data=xml_tree.find('Key'+presetnum)
+            snap=ET.SubElement(data,'Source')
+            snap.text = "SPOTIFY"
+
+        try:
+            xml_tree.find('Key'+presetnum+'/PicUrl').text = "https://brands.home-assistant.io/_/media_player/icon.png"
+        except:
+            data=xml_tree.find('Key'+presetnum)
+            snap=ET.SubElement(data,'PicUrl')
+            snap.text = "https://brands.home-assistant.io/_/media_player/icon.png"
+
         preset_map = ET.tostring(xml_tree, encoding='unicode')
         
         try:


### PR DESCRIPTION
- added possibilty to specify multiple entity ids separated by comma or use `all` to run the services against
- fixed Spotify snapshot for devices which had an empty last preset
- removed TuneIn coverart support, as it caused more bad than good. Better get info from stream's icecast headers + coverarts based on that from Last.Fm