### PR TITLE
Revert "Return duration and position for finite streams"

### DIFF
--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -381,7 +381,7 @@ class LinkPlayDevice(MediaPlayerEntity):
     @property
     def media_position(self):
         """Time in seconds of current playback head position."""
-        if (self._playhead_position > 0) and (self._duration > 0):
+        if self._playing_localfile or self._playing_spotify or self._slave_mode:
             return self._playhead_position
         else:
             return None
@@ -389,7 +389,7 @@ class LinkPlayDevice(MediaPlayerEntity):
     @property
     def media_duration(self):
         """Time in seconds of current song duration."""
-        if (self._playhead_position > 0) and (self._duration > 0):
+        if self._playing_localfile or self._playing_spotify or self._slave_mode:
             return self._duration
         else:
             return None


### PR DESCRIPTION
Reverts nagyrobi/home-assistant-custom-components-linkplay#27

Sorry, generates error when playing stream:
```
2021-03-06 10:24:36 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 621, in _update_entity_states
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 282, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 321, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/usr/src/homeassistant/homeassistant/components/media_player/__init__.py", line 843, in state_attributes
    value = getattr(self, attr)
  File "/config/custom_components/linkplay/media_player.py", line 392, in media_duration
    if (self._playhead_position > 0) and (self._duration > 0):
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```