### PR TITLE
fix: Fixed loading media player entity on startup/reload when device is offline

### DIFF
--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -270,7 +270,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     else:
         _LOGGER.warning(
             "Get Status UUID failed, response code: %s Full message: %s",
-            response.status,
+            response.status if response is not None else "Unknown",
             response,
         )
         state = STATE_UNAVAILABLE


### PR DESCRIPTION
Fixes issue reported in https://github.com/nagyrobi/home-assistant-custom-components-linkplay/issues/116