### PR TITLE
Fix async_detect_stream_url_redirection()

### DIFF
--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -18,6 +18,7 @@ import binascii
 import urllib.request
 import string
 import aiohttp
+
 from http import HTTPStatus
 from aiohttp.client_exceptions import ClientError
 from aiohttp.hdrs import CONNECTION, KEEP_ALIVE
@@ -1985,16 +1986,17 @@ class LinkPlayDevice(MediaPlayerEntity):
         check_uri = uri
         try:
             while redirect_detect:
-                response_location = requests.head(check_uri, allow_redirects=False, headers={'User-Agent': 'VLC/3.0.16 LibVLC/3.0.16'})
-                #_LOGGER.debug('For: %s detecting URI redirect code: %s', self._name, str(response_location.status_code))
-                if response_location.status_code in [301, 302, 303, 307, 308] and 'Location' in response_location.headers:
-                    #_LOGGER.debug('For: %s detecting URI redirect location: %s', self._name, response_location.headers['Location'])
+                headsession = async_get_clientsession(self.hass)
+                response_location = await headsession.head(check_uri, allow_redirects=False, headers={'User-Agent': 'VLC/3.0.16 LibVLC/3.0.16'})
+                _LOGGER.debug('For: %s detecting URI redirect code: %s', self._name, str(response_location.status))
+                if response_location.status in [301, 302, 303, 307, 308] and 'Location' in response_location.headers:
+                    _LOGGER.debug('For: %s detecting URI redirect location: %s', self._name, response_location.headers['Location']) 
                     check_uri = response_location.headers['Location']
                 else:
-                    #_LOGGER.debug('For: %s detecting URI redirect - result: %s', self._name, check_uri)
+                    _LOGGER.debug('For: %s detecting URI redirect - result: %s', self._name, check_uri)
                     redirect_detect = False
-        except:
-            pass
+        except Exception as error:
+            _LOGGER.debug("Exception:" + str(error))
 
         _LOGGER.debug('For: %s detect URI redirect - to:   %s', self._name, check_uri)
         return check_uri


### PR DESCRIPTION
Before this PR, `async_detect_stream_url_redirection()` wasn't actually doing what it should:
An ignored exception was always thrown because package `requests` wasn't being imported, and `pass` was in the `except` block.

In any case `requests` can't be used here directly. This refactors it to use `async_get_clientsession()`, and now it will correctly follow redirects.

### Testing

In home assistant, visit `/developer-tools/service`:
- Choose `media_player:play_media` as the service
- In Targets, choose the entity of your linkplay device
- In content id, use a URL that you know redirects. For example: `http://playerservices.streamtheworld.com/api/livestream-redirect/KAN_88.mp3?dist=bynetredirect`
- In content type, enter `url`
- Click on "Call Service"
<img width="500" alt="Screenshot 2023-12-14 at 16 13 05" src="https://github.com/nagyrobi/home-assistant-custom-components-linkplay/assets/844866/6f14c258-e3f7-43cd-ac57-0bf8bd79bd2d">

